### PR TITLE
ensure all bytes to base 64 conversions are URL safe. Use UTF8 encodi…

### DIFF
--- a/Modo2Auth.cs
+++ b/Modo2Auth.cs
@@ -34,14 +34,20 @@ namespace Modo
             String message = String.Format("{0}.{1}", _header, payload);
             byte[] message_bytes = Encoding.ASCII.GetBytes(message);
 
-            byte[] hashBytes = _hmac.ComputeHash(message_bytes);
+            byte[] hashBytes;
+            lock(_hmac) {
+                hashBytes = _hmac.ComputeHash(message_bytes);
+            }
             String signature = toBase64UrlSafeString(hashBytes);
             return signature;
         }
 
         public String createModoToken(String uri, byte[] body) {
 
-            byte[] hashBytes = _shaGenerator.ComputeHash(body);;
+            byte[] hashBytes;
+            lock(_shaGenerator) {
+                hashBytes = _shaGenerator.ComputeHash(body);
+            }
             String bodySha = BitConverter.ToString(hashBytes).Replace("-","").ToLower();    // also remove the - chars that c# adds in the conversion
 
             // Current time in seconds since Epoch

--- a/Modo2Auth.cs
+++ b/Modo2Auth.cs
@@ -20,7 +20,13 @@ namespace Modo
             _shaGenerator = SHA256.Create();
 
             _apiId = apiId;
-            _header = Convert.ToBase64String(Encoding.ASCII.GetBytes(cHeaderPlain)).TrimEnd('=');
+            _header = toBase64UrlSafeString( Encoding.ASCII.GetBytes(cHeaderPlain) );
+        }
+
+        private String toBase64UrlSafeString(byte[] bytes) {
+            String base64String = Convert.ToBase64String(bytes);
+            base64String = base64String.TrimEnd('=').Replace('+', '-').Replace('/', '_');
+            return base64String;
         }
 
         private String createSignature(String payload)
@@ -29,20 +35,14 @@ namespace Modo
             byte[] message_bytes = Encoding.ASCII.GetBytes(message);
 
             byte[] hashBytes = _hmac.ComputeHash(message_bytes);
-
-            String signature = Convert.ToBase64String(hashBytes);
-            signature = signature.TrimEnd('=').Replace('+', '-').Replace('/', '_');
+            String signature = toBase64UrlSafeString(hashBytes);
             return signature;
         }
 
-        public String createModoToken(String uri, String body="")
-        {
-            if (body == null)
-                body = "";
+        public String createModoToken(String uri, byte[] body) {
 
-            // Get a SHA of the request body 
-            byte[] hashBytes = _shaGenerator.ComputeHash(Encoding.ASCII.GetBytes(body));
-            String bodySha = BitConverter.ToString(hashBytes).Replace("-","").ToLower();
+            byte[] hashBytes = _shaGenerator.ComputeHash(body);;
+            String bodySha = BitConverter.ToString(hashBytes).Replace("-","").ToLower();    // also remove the - chars that c# adds in the conversion
 
             // Current time in seconds since Epoch
             TimeSpan t = DateTime.UtcNow - _epochDate;
@@ -50,7 +50,7 @@ namespace Modo
 
             // create the payload base64 string (trimmed)
             String payloadPlain = String.Format("{{\"iat\":{0},\"api_identifier\":\"{1}\",\"api_uri\":\"{2}\",\"body_hash\":\"{3}\"}}", secondsSinceEpoch, _apiId, uri, bodySha);
-            String payload = Convert.ToBase64String(Encoding.ASCII.GetBytes(payloadPlain)).TrimEnd('=');
+            String payload = toBase64UrlSafeString( Encoding.ASCII.GetBytes(payloadPlain) );
 
             // Sign it with the API secret
             String signature = createSignature(payload);
@@ -59,6 +59,21 @@ namespace Modo
             String modoAuthToken = String.Format("MODO2 {0}.{1}.{2}", _header, payload, signature);
 
             return modoAuthToken;
+        }
+
+        public String createModoToken(String uri) {
+            return createModoToken(uri, "", Encoding.UTF8);
+        }
+
+        public String createModoToken(String uri, String body, Encoding encodingScheme)
+        {
+            if (body == null)
+                body = "";
+
+            // Get a SHA of the request body 
+            byte[] bodyBytes = encodingScheme.GetBytes(body);
+
+            return createModoToken(uri, bodyBytes);
         }
 
     }

--- a/Program.cs
+++ b/Program.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Net;
 using System.IO;
-
+using System.Text;
 
 namespace Modo
 {
@@ -25,7 +25,7 @@ namespace Modo
             request.Method = WebRequestMethods.Http.Post;
 
             // Add our auth token to the http POST
-            request.Headers.Add("Authorization", auth.createModoToken(apiUri, requestBody));
+            request.Headers.Add("Authorization", auth.createModoToken(apiUri, requestBody, Encoding.UTF8));
 
             // Write out the body contents
             using (StreamWriter streamWriter = new StreamWriter(request.GetRequestStream()))

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ request.Method = WebRequestMethods.Http.Post;
 
 # 4 - Create an auth token from the apiUri and requestBody, then add it to the Auth header
 ## 4 Note: apiUri is the request path after the server name/IP address
-request.Headers.Add("Authorization", auth.createModoToken(apiUri, requestBody));
+request.Headers.Add("Authorization", auth.createModoToken(apiUri, requestBody, Encoding.UTF8));
 
 # 5 - Send the HTTP Request
 using (StreamWriter streamWriter = new StreamWriter(request.GetRequestStream()))


### PR DESCRIPTION
…ng of the body in the sample code. Allow for other methods to create the auth header.